### PR TITLE
Fixes file upload for Filament 3

### DIFF
--- a/resources/js/editor.js
+++ b/resources/js/editor.js
@@ -26,7 +26,7 @@ document.addEventListener("alpine:init", () => {
             blob,
             (uploadedFilename) => {
               this.$wire
-                .getComponentFileAttachmentUrl(statePath)
+                .getFormComponentFileAttachmentUrl(statePath)
                 .then((url) => {
                   if (!url) {
                     return resolve({


### PR DESCRIPTION
Replaces `getComponentFileAttachmentUrl` with `getFormComponentFileAttachmentUrl`